### PR TITLE
fix(restore-point): use real-*-command instead

### DIFF
--- a/restore-point.el
+++ b/restore-point.el
@@ -44,7 +44,8 @@
 
 ;; Code:
 
-(defgroup restore-point
+(defgroup restore-point nil
+  "Restore position after `keyboard-quit'."
   :link '(url-link :tag "Homepage"
           "https://github.com/arthurcgusmao/restore-point")
   :group 'convenience

--- a/restore-point.el
+++ b/restore-point.el
@@ -52,7 +52,7 @@ positions of the current buffer, most recent first.")
 Start discarding off end if gets this big.")
 
 (defvar rp/restore-point-commands
-  '[beginning-of-buffer
+  '(beginning-of-buffer
     end-of-buffer
     mark-defun
     mark-page
@@ -70,8 +70,8 @@ Start discarding off end if gets this big.")
     scroll-other-window-down
     scroll-up scroll-down
     scroll-up-command
-    rp/point-ring-nav-previous]
-  "Vector of commands for which the point position will be pushed
+    rp/point-ring-nav-previous)
+  "List of commands for which the point position will be pushed
 to `rp/point-ring' before being called.")
 
 (defun rp/push-point-ring ()
@@ -110,8 +110,8 @@ to `rp/point-ring' before being called.")
 restore-point command from an ordinary one. To be added to
 `pre-command-hook' list when activating this minor mode."
   (when (and (not (eq real-this-command real-last-command))
-             (cl-find real-this-command rp/restore-point-commands)
-             (not (cl-find real-last-command rp/restore-point-commands)))
+             (memq real-this-command rp/restore-point-commands)
+             (not (memq real-last-command rp/restore-point-commands)))
     (rp/push-point-ring)))
 
 ;; Restore point advice function
@@ -119,7 +119,7 @@ restore-point command from an ordinary one. To be added to
   "Restore point position if last command in
 `rp/restore-point-commands' list. To be added as advice to
 `keyboard-quit' when activating this minor mode."
-  (when (cl-find real-last-command rp/restore-point-commands)
+  (when (memq real-last-command rp/restore-point-commands)
     (rp/restore-point-position)))
 
 

--- a/restore-point.el
+++ b/restore-point.el
@@ -42,7 +42,7 @@
 ;; Kai Yu, which can be found in
 ;; https://github.com/zhangkaiyulw/smart-mark/blob/master/smart-mark.el
 
-;; Code:
+;;; Code:
 
 (defgroup restore-point nil
   "Restore position after `keyboard-quit'."
@@ -51,8 +51,8 @@
   :group 'convenience
   :prefix "rp/")
 
-(defvar-local rp/point-ring nil "List of former point
-positions of the current buffer, most recent first.")
+(defvar-local rp/point-ring nil
+  "List of former point positions of the current buffer, most recent first.")
 (put 'rp/point-ring 'permanent-local t)
 
 (defcustom rp/point-ring-max 128 "Maximum size of point ring.
@@ -80,8 +80,7 @@ Start discarding off end if gets this big."
     scroll-up scroll-down
     scroll-up-command
     rp/point-ring-nav-previous)
-  "List of commands for which the point position will be pushed
-to `rp/point-ring' before being called."
+  "Commands that push the point position to `rp/point-ring' before execution."
   :type '(repeat symbol)
   :group 'restore-point)
 

--- a/restore-point.el
+++ b/restore-point.el
@@ -52,7 +52,7 @@ positions of the current buffer, most recent first.")
 Start discarding off end if gets this big.")
 
 (defvar rp/restore-point-commands
-  '(beginning-of-buffer
+  '[beginning-of-buffer
     end-of-buffer
     mark-defun
     mark-page
@@ -70,8 +70,8 @@ Start discarding off end if gets this big.")
     scroll-other-window-down
     scroll-up scroll-down
     scroll-up-command
-    rp/point-ring-nav-previous)
-  "List of commands for which the point position will be pushed
+    rp/point-ring-nav-previous]
+  "Vector of commands for which the point position will be pushed
 to `rp/point-ring' before being called.")
 
 (defun rp/push-point-ring ()
@@ -110,8 +110,8 @@ to `rp/point-ring' before being called.")
 restore-point command from an ordinary one. To be added to
 `pre-command-hook' list when activating this minor mode."
   (when (and (not (eq real-this-command real-last-command))
-             (memq real-this-command rp/restore-point-commands)
-             (not (memq real-last-command rp/restore-point-commands)))
+             (cl-find real-this-command rp/restore-point-commands)
+             (not (cl-find real-last-command rp/restore-point-commands)))
     (rp/push-point-ring)))
 
 ;; Restore point advice function
@@ -119,7 +119,7 @@ restore-point command from an ordinary one. To be added to
   "Restore point position if last command in
 `rp/restore-point-commands' list. To be added as advice to
 `keyboard-quit' when activating this minor mode."
-  (when (memq real-last-command rp/restore-point-commands)
+  (when (cl-find real-last-command rp/restore-point-commands)
     (rp/restore-point-position)))
 
 

--- a/restore-point.el
+++ b/restore-point.el
@@ -44,14 +44,22 @@
 
 ;; Code:
 
+(defgroup restore-point
+  :link '(url-link :tag "Homepage"
+          "https://github.com/arthurcgusmao/restore-point")
+  :group 'convenience
+  :prefix "rp/")
+
 (defvar-local rp/point-ring nil "List of former point
 positions of the current buffer, most recent first.")
 (put 'rp/point-ring 'permanent-local t)
 
-(defvar rp/point-ring-max 128 "Maximum size of point ring.
-Start discarding off end if gets this big.")
+(defcustom rp/point-ring-max 128 "Maximum size of point ring.
+Start discarding off end if gets this big."
+  :type 'natnum
+  :group 'restore-point)
 
-(defvar rp/restore-point-commands
+(defcustom rp/restore-point-commands
   '(beginning-of-buffer
     end-of-buffer
     mark-defun
@@ -72,7 +80,9 @@ Start discarding off end if gets this big.")
     scroll-up-command
     rp/point-ring-nav-previous)
   "List of commands for which the point position will be pushed
-to `rp/point-ring' before being called.")
+to `rp/point-ring' before being called."
+  :type '(repeat symbol)
+  :group 'restore-point)
 
 (defun rp/push-point-ring ()
   "Push current point position to point ring."

--- a/restore-point.el
+++ b/restore-point.el
@@ -84,6 +84,9 @@ to `rp/point-ring' before being called."
   :type '(repeat symbol)
   :group 'restore-point)
 
+(defvar rp/nav-nth 1
+  "Current index for navigation with `rp/point-ring-nav-previous'.")
+
 (defun rp/push-point-ring ()
   "Push current point position to point ring."
   (interactive)

--- a/restore-point.el
+++ b/restore-point.el
@@ -109,7 +109,7 @@ to `rp/point-ring' before being called."
 (defun rp/point-ring-nav-previous ()
   "Navigates the `rp/point-ring' backwards."
   (interactive)
-  (if (eq real-this-command real-last-command)
+  (if (eq this-command last-command)
       (setq rp/nav-nth (1+ rp/nav-nth))
     (setq rp/nav-nth 1))
   (let ((marker (nth rp/nav-nth rp/point-ring)))

--- a/restore-point.el
+++ b/restore-point.el
@@ -1,4 +1,4 @@
-;;; restore-point.el --- Restore point position after mark or scroll functions
+;;; restore-point.el --- Restore point position after mark or scroll functions -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2019 Arthur Colombini Gusmão
 

--- a/restore-point.el
+++ b/restore-point.el
@@ -90,7 +90,8 @@ to `rp/point-ring' before being called.")
 (defun rp/restore-point-position ()
   "Restore most recent point position from ring."
   (interactive)
-  (goto-char (nth 0 rp/point-ring)))
+  (and rp/point-ring
+       (goto-char (nth 0 rp/point-ring))))
 
 (defun rp/point-ring-nav-previous ()
   "Navigates the `rp/point-ring' backwards."

--- a/restore-point.el
+++ b/restore-point.el
@@ -95,7 +95,7 @@ to `rp/point-ring' before being called.")
 (defun rp/point-ring-nav-previous ()
   "Navigates the `rp/point-ring' backwards."
   (interactive)
-  (if (eq this-command last-command)
+  (if (eq real-this-command real-last-command)
       (setq rp/nav-nth (1+ rp/nav-nth))
     (setq rp/nav-nth 1))
   (let ((marker (nth rp/nav-nth rp/point-ring)))
@@ -108,9 +108,9 @@ to `rp/point-ring' before being called.")
   "Push point position to ring when transitioning to a
 restore-point command from an ordinary one. To be added to
 `pre-command-hook' list when activating this minor mode."
-  (when (and (not (eq this-command last-command))
-             (memq this-command rp/restore-point-commands)
-             (not (memq last-command rp/restore-point-commands)))
+  (when (and (not (eq real-this-command real-last-command))
+             (memq real-this-command rp/restore-point-commands)
+             (not (memq real-last-command rp/restore-point-commands)))
     (rp/push-point-ring)))
 
 ;; Restore point advice function
@@ -118,7 +118,7 @@ restore-point command from an ordinary one. To be added to
   "Restore point position if last command in
 `rp/restore-point-commands' list. To be added as advice to
 `keyboard-quit' when activating this minor mode."
-  (when (memq last-command rp/restore-point-commands)
+  (when (memq real-last-command rp/restore-point-commands)
     (rp/restore-point-position)))
 
 

--- a/restore-point.el
+++ b/restore-point.el
@@ -128,7 +128,7 @@ restore-point command from an ordinary one. To be added to
     (rp/push-point-ring)))
 
 ;; Restore point advice function
-(defun rp/cond-restore-point (&rest args)
+(defun rp/cond-restore-point (&rest _)
   "Restore point position if last command in
 `rp/restore-point-commands' list. To be added as advice to
 `keyboard-quit' when activating this minor mode."


### PR DESCRIPTION
Evil sets `this-command` to `previous-line` and `next-line` for a lot of scrolling commands (e.g. `evil-scroll-up` and `evil-scroll-down`). This causes `restore-point` to not save the point when scrolling. This commit fixes this by using `real-this-command` and `real-last-command` instead of `this-command` and `last-command`.