### PR TITLE
enable lexical binding

### DIFF
--- a/restore-point.el
+++ b/restore-point.el
@@ -1,4 +1,4 @@
-;;; restore-point.el --- Restore point position after mark or scroll functions
+;;; restore-point.el --- Restore point position after mark or scroll functions -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2019 Arthur Colombini Gusmão
 


### PR DESCRIPTION
Hi. I have inspected your codebase and found no code which presents a problem with enabling `lexical-binding`. One day Emacs will enable lexical binding by default so it's better merge this earlier to reduce the risk of a mass config breakage event. 